### PR TITLE
Fix a bug that previously broke the propensity option

### DIFF
--- a/src/causalBoosting.c
+++ b/src/causalBoosting.c
@@ -289,7 +289,7 @@ double splitCriterion_propensity(double *y, int *tx, double *w, int *a, int *b, 
   free(txA);
   free(cxA);
   free(txB);
-  free(txB);
+  free(cxB);
   free(txAw);
   free(cxAw);
   free(txBw);


### PR DESCRIPTION
There is a bug caused by mistyping in a previous commit. This PR tries to fix that.

```
> library(causalLearning)
> set.seed(1223)
> n = 100 # number of training-set patients to simulate
> p = 10  # number of features for each training-set patient
> x = matrix(rnorm(n * p), nrow = n, ncol = p) # simulate covariate matrix
> tx_effect = x[, 1] + (x[, 2] > 0) # simple heterogeneous treatment effect
> tx = rbinom(n, size = 1, p = 0.5) # random treatment assignment
> y = rowMeans(x) + tx * tx_effect + rnorm(n, sd = 0.001) # simulate response
> stratum = sample(rep(1:2, length = n))
> table(tx, stratum)
   stratum
tx   1  2
  0 34 29
  1 16 21
> #   stratum
> #tx   1  2
> #  0 23 21
> #  1 27 29
> fit_cb = causalLearning::causalBoosting(x, tx, y, num.trees = 500, propensity = TRUE, stratum = stratum)
> dim(fit_cb$tauhat)
[1] 100 500
```